### PR TITLE
Fix BC7 modes 0, 1, 2, and 3 refinement step when the source data supplies an alpha channel. (Determinism/correctness)

### DIFF
--- a/ISPC Texture Compressor/ispc_texcomp/kernel.ispc
+++ b/ISPC Texture Compressor/ispc_texcomp/kernel.ispc
@@ -1357,7 +1357,7 @@ void bc7_enc_mode01237(bc7_enc_state state[], uniform int mode, int part_list[],
 		int qep[24];
 		uint32 qblock[2];
 
-		ep_quant_dequant(qep, ep, mode, state->channels);
+		ep_quant_dequant(qep, ep, mode, channels);
 		
 		uint32 pattern = get_pattern(best_part_id);
 		float err = block_quant(qblock, state->block, bits, ep, pattern, channels);


### PR DESCRIPTION
The `bc7_enc_mode01237` subroutine was passing `state->channels` (i.e. number of channels for the whole image) downstream instead of the local variable `channels` (i.e. number of channels for the specific BC7 mode we are attempting). The alpha channel is usually ignored (i.e. left uninitialized), so not ignoring it in this case meant reading potentially-uninitialized stack memory and using it for the error metric.

This was quite fun to track down, since the nondeterminism only showed up when the executable was relinked. :)
