### PR TITLE
Adding API for BC4/BC5 compression

### DIFF
--- a/ISPC Texture Compressor/main.cpp
+++ b/ISPC Texture Compressor/main.cpp
@@ -198,6 +198,8 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     else
     {
         CDXUTComboBox *comboBox = gSampleUI.GetComboBox(IDC_PROFILE);
+        comboBox->AddItem(L"BC4 (R)", (void*)(CompressImageBC4));
+        comboBox->AddItem(L"BC5 (RG)", (void*)(CompressImageBC5));
         comboBox->AddItem(L"BC6H veryfast", (void *)(CompressImageBC6H_veryfast));
         comboBox->AddItem(L"BC6H fast", (void *)(CompressImageBC6H_fast));
         comboBox->AddItem(L"BC6H basic", (void *)(CompressImageBC6H_basic));

--- a/ISPC Texture Compressor/processing.cpp
+++ b/ISPC Texture Compressor/processing.cpp
@@ -374,8 +374,8 @@ HRESULT CompressTexture(ID3D11ShaderResourceView* uncompressedSRV, ID3D11ShaderR
         {
             for(UINT x = 0; x < uncompTexDesc.Width; ++x, ++offset)
             {
-                // copy alpha over
-                bc4bc5bytes[offset] = reinterpret_cast<BYTE*>(uncompData.pData)[(x * 4) + (y * uncompData.RowPitch) + 3];
+                // copy R over
+                bc4bc5bytes[offset] = reinterpret_cast<BYTE*>(uncompData.pData)[(x * 4) + (y * uncompData.RowPitch) + 0];
             }
         }
     }

--- a/ISPC Texture Compressor/processing.cpp
+++ b/ISPC Texture Compressor/processing.cpp
@@ -364,6 +364,35 @@ HRESULT CompressTexture(ID3D11ShaderResourceView* uncompressedSRV, ID3D11ShaderR
     D3D11_MAPPED_SUBRESOURCE compData;
     V_RETURN(deviceContext->Map(compStgTex, D3D11CalcSubresource(0, 0, 1), D3D11_MAP_READ_WRITE, 0, &compData));
 
+    const bool isBC4 = IsBC4(gCompressionFunc);
+    const bool isBC5 = IsBC5(gCompressionFunc);
+    std::vector<BYTE> bc4bc5bytes;
+    if(isBC4)
+    {
+        bc4bc5bytes.resize(uncompTexDesc.Width * uncompTexDesc.Height);
+        for(UINT y = 0, offset = 0; y < uncompTexDesc.Height; ++y)
+        {
+            for(UINT x = 0; x < uncompTexDesc.Width; ++x, ++offset)
+            {
+                // copy alpha over
+                bc4bc5bytes[offset] = reinterpret_cast<BYTE*>(uncompData.pData)[(x * 4) + (y * uncompData.RowPitch) + 3];
+            }
+        }
+    }
+    else if(isBC5)
+    {
+        bc4bc5bytes.resize(uncompTexDesc.Width * uncompTexDesc.Height * 2);
+        for(UINT y = 0, offset = 0; y < uncompTexDesc.Height; ++y)
+        {
+            for(UINT x = 0; x < uncompTexDesc.Width; ++x, offset += 2)
+            {
+                // copy R and G over
+                bc4bc5bytes[offset + 0] = reinterpret_cast<BYTE*>(uncompData.pData)[(x * 4) + (y * uncompData.RowPitch) + 0];
+                bc4bc5bytes[offset + 1] = reinterpret_cast<BYTE*>(uncompData.pData)[(x * 4) + (y * uncompData.RowPitch) + 1];
+            }
+        }
+    }
+
     // Time the compression.
     StopWatch stopWatch;
     stopWatch.Start();
@@ -372,8 +401,8 @@ HRESULT CompressTexture(ID3D11ShaderResourceView* uncompressedSRV, ID3D11ShaderR
     for(int cmpNum = 0; cmpNum < kNumCompressions; cmpNum++)
     {
         rgba_surface input;
-        input.ptr = (BYTE*)uncompData.pData;
-        input.stride = uncompData.RowPitch;
+        input.ptr = (isBC4 || isBC5) ? bc4bc5bytes.data() : (BYTE*)uncompData.pData;
+        input.stride = isBC4 ? uncompTexDesc.Width : (isBC5 ? (uncompTexDesc.Width * 2) : uncompData.RowPitch);
         input.width = uncompTexDesc.Width;
         input.height = uncompTexDesc.Height;
 
@@ -419,6 +448,8 @@ static inline DXGI_FORMAT GetNonSRGBFormat(DXGI_FORMAT f) {
     switch(f) {
         case DXGI_FORMAT_BC1_UNORM_SRGB: return DXGI_FORMAT_BC1_UNORM;
         case DXGI_FORMAT_BC3_UNORM_SRGB: return DXGI_FORMAT_BC3_UNORM;
+        case DXGI_FORMAT_BC4_UNORM:      return DXGI_FORMAT_BC4_UNORM;
+        case DXGI_FORMAT_BC5_UNORM:      return DXGI_FORMAT_BC5_UNORM;
         case DXGI_FORMAT_BC7_UNORM_SRGB: return DXGI_FORMAT_BC7_UNORM;
         case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: return DXGI_FORMAT_R8G8B8A8_UNORM;
         default: assert(!"Unknown format!");
@@ -1087,13 +1118,25 @@ int GetBytesPerBlock(CompressionFunc* fn)
     {
         default:
         case DXGI_FORMAT_BC1_UNORM_SRGB:
+        case DXGI_FORMAT_BC4_UNORM:
             return 8;
 
         case DXGI_FORMAT_BC3_UNORM_SRGB:
+        case DXGI_FORMAT_BC5_UNORM:
         case DXGI_FORMAT_BC7_UNORM_SRGB:
         case DXGI_FORMAT_BC6H_UF16:
             return 16;
     }
+}
+
+bool IsBC4(CompressionFunc* fn)
+{
+    return fn == CompressImageBC4;
+}
+
+bool IsBC5(CompressionFunc* fn)
+{
+    return fn == CompressImageBC5;
 }
 
 bool IsBC6H(CompressionFunc* fn)
@@ -1110,6 +1153,8 @@ DXGI_FORMAT GetFormatFromCompressionFunc(CompressionFunc* fn)
 {
     if (fn == CompressImageBC1) return DXGI_FORMAT_BC1_UNORM_SRGB;
     if (fn == CompressImageBC3) return DXGI_FORMAT_BC3_UNORM_SRGB;
+    if (fn == CompressImageBC4) return DXGI_FORMAT_BC4_UNORM;
+    if (fn == CompressImageBC5) return DXGI_FORMAT_BC5_UNORM;
 
     if (IsBC6H(fn)) return DXGI_FORMAT_BC6H_UF16;
 
@@ -1124,6 +1169,16 @@ void CompressImageBC1(const rgba_surface* input, BYTE* output)
 void CompressImageBC3(const rgba_surface* input, BYTE* output)
 {
     CompressBlocksBC3(input, output);
+}
+
+void CompressImageBC4(const rgba_surface* input, BYTE* output)
+{
+    CompressBlocksBC4(input, output);
+}
+
+void CompressImageBC5(const rgba_surface* input, BYTE* output)
+{
+    CompressBlocksBC5(input, output);
 }
 
 #define DECLARE_CompressImageBC6H_profile(profile)                              \

--- a/ISPC Texture Compressor/processing.h
+++ b/ISPC Texture Compressor/processing.h
@@ -91,10 +91,14 @@ DWORD WINAPI CompressImageMT_Thread( LPVOID lpParam );
 
 int GetBytesPerBlock(CompressionFunc* fn);
 bool IsBC6H(CompressionFunc* fn);
+bool IsBC4(CompressionFunc* fn);
+bool IsBC5(CompressionFunc* fn);
 DXGI_FORMAT GetFormatFromCompressionFunc(CompressionFunc* fn);
 
 void CompressImageBC1(const rgba_surface* input, BYTE* output);
 void CompressImageBC3(const rgba_surface* input, BYTE* output);
+void CompressImageBC4(const rgba_surface* input, BYTE* output);
+void CompressImageBC5(const rgba_surface* input, BYTE* output);
 void CompressImageBC6H_veryfast(const rgba_surface* input, BYTE* output);
 void CompressImageBC6H_fast(const rgba_surface* input, BYTE* output);
 void CompressImageBC6H_basic(const rgba_surface* input, BYTE* output);

--- a/ispc_texcomp/ispc_texcomp.cpp
+++ b/ispc_texcomp/ispc_texcomp.cpp
@@ -456,6 +456,16 @@ void CompressBlocksBC3(const rgba_surface* src, uint8_t* dst)
 	ispc::CompressBlocksBC3_ispc((ispc::rgba_surface*)src, dst);
 }
 
+void CompressBlocksBC4(const rgba_surface* src, uint8_t* dst)
+{
+	ispc::CompressBlocksBC4_ispc((ispc::rgba_surface*)src, dst);
+}
+
+void CompressBlocksBC5(const rgba_surface* src, uint8_t* dst)
+{
+	ispc::CompressBlocksBC5_ispc((ispc::rgba_surface*)src, dst);
+}
+
 void CompressBlocksBC7(const rgba_surface* src, uint8_t* dst, bc7_enc_settings* settings)
 {
 	ispc::CompressBlocksBC7_ispc((ispc::rgba_surface*)src, dst, (ispc::bc7_enc_settings*)settings);

--- a/ispc_texcomp/ispc_texcomp.def
+++ b/ispc_texcomp/ispc_texcomp.def
@@ -2,6 +2,8 @@ LIBRARY   ispc_texcomp
 EXPORTS
 	CompressBlocksBC1
 	CompressBlocksBC3
+    CompressBlocksBC4
+    CompressBlocksBC5
 	CompressBlocksBC6H
 	CompressBlocksBC7
 	CompressBlocksETC1

--- a/ispc_texcomp/ispc_texcomp.h
+++ b/ispc_texcomp/ispc_texcomp.h
@@ -106,9 +106,10 @@ extern "C" void ReplicateBorders(rgba_surface* dst_slice, const rgba_surface* sr
 Notes:
     - input width and height need to be a multiple of block size
     - LDR input is 32 bit/pixel (sRGB), HDR is 64 bit/pixel (half float)
+        - for BC4 input is 8bit/pixel (R8), for BC5 input is 16bit/pixel (RG8)
     - dst buffer must be allocated with enough space for the compressed texture:
-        - 8 bytes/block for BC1/ETC1,
-        - 16 bytes/block for BC3/BC6H/BC7/ASTC
+        - 8 bytes/block for BC1/BC4/ETC1,
+        - 16 bytes/block for BC3/BC5/BC6H/BC7/ASTC
     - the blocks are stored in raster scan order (natural CPU texture layout)
     - use the GetProfile_* functions to select various speed/quality tradeoffs
     - the RGB profiles are slightly faster as they ignore the alpha channel
@@ -116,6 +117,8 @@ Notes:
 
 extern "C" void CompressBlocksBC1(const rgba_surface* src, uint8_t* dst);
 extern "C" void CompressBlocksBC3(const rgba_surface* src, uint8_t* dst);
+extern "C" void CompressBlocksBC4(const rgba_surface* src, uint8_t* dst);
+extern "C" void CompressBlocksBC5(const rgba_surface* src, uint8_t* dst);
 extern "C" void CompressBlocksBC6H(const rgba_surface* src, uint8_t* dst, bc6h_enc_settings* settings);
 extern "C" void CompressBlocksBC7(const rgba_surface* src, uint8_t* dst, bc7_enc_settings* settings);
 extern "C" void CompressBlocksETC1(const rgba_surface* src, uint8_t* dst, etc_enc_settings* settings);

--- a/ispc_texcomp/kernel.ispc
+++ b/ispc_texcomp/kernel.ispc
@@ -166,6 +166,41 @@ inline void load_block_interleaved_16bit(float block[48], uniform rgba_surface* 
     }
 }
 
+inline void load_block_r_8bit(float block[16], uniform rgba_surface* uniform src, int xx, uniform int yy)
+{
+	for (uniform int y=0; y<4; y++)
+	{
+		uniform unsigned int32* uniform src_ptr = (unsigned int32*)&src->ptr[(yy*4+y)*src->stride];
+		unsigned int32 rrrr = gather_uint(src_ptr, xx);
+
+		block[y*4+0] = (int)((rrrr>> 0)&255);
+		block[y*4+1] = (int)((rrrr>> 8)&255);
+		block[y*4+2] = (int)((rrrr>>16)&255);
+		block[y*4+3] = (int)((rrrr>>24)&255);
+	}
+}
+
+inline void load_block_interleaved_rg_8bit(float block[32], uniform rgba_surface* uniform src, int xx, uniform int yy)
+{
+	for (uniform int y=0; y<4; y++)
+	{
+		uniform unsigned int32* uniform src_ptr = (unsigned int32*)&src->ptr[(yy*4+y)*src->stride];
+		unsigned int32 rgrg0 = gather_uint(src_ptr, xx * 2 + 0);
+        unsigned int32 rgrg1 = gather_uint(src_ptr, xx * 2 + 1);
+
+        // r
+		block[16*0+y*4+0] = (int)((rgrg0>> 0)&255);
+		block[16*0+y*4+1] = (int)((rgrg0>>16)&255);
+		block[16*0+y*4+2] = (int)((rgrg1>> 0)&255);
+		block[16*0+y*4+3] = (int)((rgrg1>>16)&255);
+        // g
+		block[16*1+y*4+0] = (int)((rgrg0>> 8)&255);
+		block[16*1+y*4+1] = (int)((rgrg0>>24)&255);
+		block[16*1+y*4+2] = (int)((rgrg1>> 8)&255);
+		block[16*1+y*4+3] = (int)((rgrg1>>24)&255);
+	}
+}
+
 inline void store_data(uniform uint8 dst[], int width, int xx, uniform int yy, uint32 data[], int data_size)
 {
 	for (uniform int k=0; k<data_size; k++)
@@ -611,6 +646,31 @@ inline void CompressBlockBC3(uniform rgba_surface src[], int xx, uniform int yy,
 	store_data(dst, src->width, xx, yy, data, 4);
 }
 
+inline void CompressBlockBC4(uniform rgba_surface src[], int xx, uniform int yy, uniform uint8 dst[])
+{
+	float block[16];
+    uint32 data[2];
+
+	load_block_r_8bit(block, src, xx, yy);
+	
+    CompressBlockBC3_alpha(block, data);
+
+	store_data(dst, src->width, xx, yy, data, 2);
+}
+
+inline void CompressBlockBC5(uniform rgba_surface src[], int xx, uniform int yy, uniform uint8 dst[])
+{
+	float block[32];
+    uint32 data[4];
+
+	load_block_interleaved_rg_8bit(block, src, xx, yy);
+	
+    CompressBlockBC3_alpha(block, data);
+    CompressBlockBC3_alpha(&block[16], &data[2]);
+
+	store_data(dst, src->width, xx, yy, data, 4);
+}
+
 export void CompressBlocksBC1_ispc(uniform rgba_surface src[], uniform uint8 dst[])
 {	
 	for (uniform int yy = 0; yy<src->height/4; yy++)
@@ -626,6 +686,24 @@ export void CompressBlocksBC3_ispc(uniform rgba_surface src[], uniform uint8 dst
 	foreach (xx = 0 ... src->width/4)
 	{
 		CompressBlockBC3(src, xx, yy, dst);
+	}
+}
+
+export void CompressBlocksBC4_ispc(uniform rgba_surface src[], uniform uint8 dst[])
+{
+	for (uniform int yy = 0; yy<src->height/4; yy++)
+	foreach (xx = 0 ... src->width/4)
+	{
+		CompressBlockBC4(src, xx, yy, dst);
+	}
+}
+
+export void CompressBlocksBC5_ispc(uniform rgba_surface src[], uniform uint8 dst[])
+{
+	for (uniform int yy = 0; yy<src->height/4; yy++)
+	foreach (xx = 0 ... src->width/4)
+	{
+		CompressBlockBC5(src, xx, yy, dst);
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ formats:
 * BC7
 * ASTC (LDR, block sizes up to 8x8)
 * ETC1
-* BC1, BC3 (aka DXT1, DXT5)
+* BC1, BC3 (aka DXT1, DXT5) and BC4, BC5 (aka ATI1N, ATI2N)
 
 The library uses the [ISPC compiler](https://ispc.github.io/) to generate CPU
 SIMD-optimized compression algorithms.  For more information, see the [Fast ISPC


### PR DESCRIPTION
It would be nice to have ISPCTextureCompressor to be able to produce any BC variant. Since it already has BC3 alpha block compression, adding BC4 and BC5 is an easy task.

I've implemented both BC4 and BC5 compression API funcs, and added these to the sample application.